### PR TITLE
preserve whitespace and break words

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -778,18 +778,18 @@ function generateMessageInfo(messages, transfersInfo, outputsUnit, assocCommissi
 				default:
 					for (var key_payload in message.payload) {
 						if (message.app == 'asset' && key_payload == 'denominations') {
-							messagesOut += '<div><strong>denominations:</strong></div>';
+							messagesOut += '<div><label>denominations:</label></div>';
 							messagesOut += '<div class="payload">';
 							messagesOut += JSON.stringify(message.payload[key_payload]);
 							messagesOut += '</div>';
 						}
 						else if (typeof message.payload[key_payload] === "object") {
-							messagesOut += '<div><strong>' + htmlEscape(key_payload) + ':</strong></div>';
+							messagesOut += '<div><label>' + htmlEscape(key_payload) + ':</label></div>';
 							messagesOut += '<div class="payload">';
 							messagesOut += htmlEscape(JSON.stringify(message.payload[key_payload]));
 							messagesOut += '</div>';
 						} else {
-							messagesOut += '<div class="payload"><strong>' + htmlEscape(key_payload) + ':</strong> ' + htmlEscape(message.payload[key_payload]) + '</div>';
+							messagesOut += '<div class="payload"><label>' + htmlEscape(key_payload) + ':</label> ' + htmlEscape(message.payload[key_payload]) + '</div>';
 						}
 					}
 					break;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -773,21 +773,23 @@ function generateMessageInfo(messages, transfersInfo, outputsUnit, assocCommissi
 					}
 					break;
 				case 'text':
-					messagesOut += '<div>Text: ' + htmlEscape(message.payload) + '</div>';
+					messagesOut += '<div class="payload">' + htmlEscape(message.payload) + '</div>';
 					break;
 				default:
 					for (var key_payload in message.payload) {
 						if (message.app == 'asset' && key_payload == 'denominations') {
-							messagesOut += '<div>denominations:</div><div>';
+							messagesOut += '<div><strong>denominations:</strong></div>';
+							messagesOut += '<div class="payload">';
 							messagesOut += JSON.stringify(message.payload[key_payload]);
 							messagesOut += '</div>';
 						}
 						else if (typeof message.payload[key_payload] === "object") {
-							messagesOut += '<div>' + htmlEscape(key_payload) + ':</div><div>';
+							messagesOut += '<div><strong>' + htmlEscape(key_payload) + ':</strong></div>';
+							messagesOut += '<div class="payload">';
 							messagesOut += htmlEscape(JSON.stringify(message.payload[key_payload]));
 							messagesOut += '</div>';
 						} else {
-							messagesOut += '<div>' + htmlEscape(key_payload + ': ' + message.payload[key_payload]) + '</div>';
+							messagesOut += '<div class="payload"><strong>' + htmlEscape(key_payload) + ':</strong> ' + htmlEscape(message.payload[key_payload]) + '</div>';
 						}
 					}
 					break;
@@ -1165,7 +1167,7 @@ $(document).on('mouseout', '.numberFormat', function() {
 
 //escape
 function htmlEscape(str) {
-	return str
+	return String(str)
 		.replace(/&/g, '&amp;')
 		.replace(/"/g, '&quot;')
 		.replace(/'/g, '&#39;')

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -773,7 +773,7 @@ function generateMessageInfo(messages, transfersInfo, outputsUnit, assocCommissi
 					}
 					break;
 				case 'text':
-					messagesOut += '<div class="payload">' + htmlEscape(message.payload) + '</div>';
+					messagesOut += '<pre class="payload">' + htmlEscape(message.payload) + '</pre>';
 					break;
 				default:
 					for (var key_payload in message.payload) {

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -245,6 +245,12 @@ pre{
 	margin: 0;
 }
 
+label {
+	color: gray;
+	font-weight: normal;
+	font-style: italic;
+}
+
 .payload {
 	white-space: pre-wrap;
 	word-wrap: break-word;

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -245,6 +245,11 @@ pre{
 	margin: 0;
 }
 
+.payload {
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
 #otherInfo > div {
 	padding: 0 5px;
 }

--- a/views/index.html
+++ b/views/index.html
@@ -4,7 +4,7 @@
 	<title>Byteball Explorer</title>
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&amp;subset=cyrillic" rel="stylesheet">
-	<link rel="stylesheet" href="/styles/app.css?v7">
+	<link rel="stylesheet" href="/styles/app.css?v8">
 	<link rel="icon" href="/img/icon_16x16@2x.png">
 </head>
 <body>
@@ -126,6 +126,6 @@
 <script src="/socket.io/socket.io.js"></script>
 <script src="/js/cytoscape.min.js"></script>
 <script src="/js/dagre.min.js"></script>
-<script src="/js/main.js?v12"></script>
+<script src="/js/main.js?v13"></script>
 </body>
 </html>


### PR DESCRIPTION
* long space-less strings were not broken to next line, causing [horizontal scrollbars](https://explorer.byteball.org/#ekUq+0FW1uf1Bm1Dos7epi6AdWy2+m8CTOzU5/04y84=).
* text output was [ignoring whitespace and newlines](https://explorer.byteball.org/#uGIebuLm7/uZkbxXH1lPoc6hxtIiWFJyn9VHpwKe7XU=).
* text outputs had unnecessary "Text: " prepended, removed it because #divTitleMessage already says: "Text" and there is no other fields in text outputs.
* text outputs are now with `<pre>` tag to have [constant letter width](https://explorer.byteball.org/#rkNYvr76R/ThV8qu+u0+p6+a1j2kHsejAg30LEsdfjY=).
* htmlEscape function threw TypeError when only number was tried to escaped.
* made field labels [distinct from values](https://explorer.byteball.org/#qO2JsiuDMh/j+pqJYZw3u82O71WjCDf0vTNvsnntr8o=).
